### PR TITLE
Add pagination capability for comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentDataServlet.java
@@ -25,6 +25,10 @@ public class CommentDataServlet extends DataServlet {
   protected final String ENTITY_KIND                = "Comment";
   private HashMap<String, String> prevCursorMap;
 
+  /**
+   * Initialize a server-side cache of previous cursors that are used in datastore pagination.
+   * The cache is updated whenever we access a new page of comments and cleared when comments are deleted.
+   **/
   public CommentDataServlet() {
     prevCursorMap   = new HashMap<String, String>();
   }
@@ -59,6 +63,10 @@ public class CommentDataServlet extends DataServlet {
     }
   }
 
+  /**
+   * Function to post a new comment.
+   * Attaches LDAP parameter to the comment to keep track of usernames.
+   **/
   private void postComment(HttpServletRequest request, HttpServletResponse response) throws IOException {
     HashMap<String,String> extraParameters = new HashMap<String, String>();
     extraParameters.put(USER_LDAP_PARAMETER, AuthCheck.getLdap());
@@ -66,11 +74,19 @@ public class CommentDataServlet extends DataServlet {
     doPost(request, response, ENTITY_KIND, extraParameters);
   }
 
+  /**
+   * Function to delete all comments.
+   * Clears prevCursorMap cache as it will no longer be valid after the comment deletion.
+   **/
   private void deleteComment(HttpServletRequest request, HttpServletResponse response) throws IOException {
     deleteAll(ENTITY_KIND);
     prevCursorMap.clear();
   }
 
+  /**
+   * Function to get a new comment.
+   * prevCursorMap cache will be updated when accessing a new page.
+   **/
   private void getComment(HttpServletRequest request, HttpServletResponse response) throws IOException {
     int commentsNumber  = parseIntParameter(request, COMMENT_NUMBER_PARAMETER);
     commentsNumber      = Math.max(commentsNumber, MIN_COMMENTS_NUMBER);

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentDataServlet.java
@@ -23,6 +23,11 @@ public class CommentDataServlet extends DataServlet {
   private static final String GET_COMMENT_URL       = "/comment-get";
   private static final String DELETE_COMMENT_URL    = "/comment-delete";
   protected final String ENTITY_KIND                = "Comment";
+  private HashMap<String, String> prevCursorMap;
+
+  public CommentDataServlet() {
+    prevCursorMap   = new HashMap<String, String>();
+  }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -63,13 +68,14 @@ public class CommentDataServlet extends DataServlet {
 
   private void deleteComment(HttpServletRequest request, HttpServletResponse response) throws IOException {
     deleteAll(ENTITY_KIND);
+    prevCursorMap.clear();
   }
 
   private void getComment(HttpServletRequest request, HttpServletResponse response) throws IOException {
     int commentsNumber  = parseIntParameter(request, COMMENT_NUMBER_PARAMETER);
     commentsNumber      = Math.max(commentsNumber, MIN_COMMENTS_NUMBER);
 
-    doGet(request, response, ENTITY_KIND, ENTITY_TIMESTAMP_PARAMETER, commentsNumber);
+    doGet(request, response, ENTITY_KIND, ENTITY_TIMESTAMP_PARAMETER, commentsNumber, prevCursorMap);
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentDataServlet.java
@@ -69,7 +69,7 @@ public class CommentDataServlet extends DataServlet {
     int commentsNumber  = parseIntParameter(request, COMMENT_NUMBER_PARAMETER);
     commentsNumber      = Math.max(commentsNumber, MIN_COMMENTS_NUMBER);
 
-    doGet(response, ENTITY_KIND, ENTITY_TIMESTAMP_PARAMETER, commentsNumber);
+    doGet(request, response, ENTITY_KIND, ENTITY_TIMESTAMP_PARAMETER, commentsNumber);
   }
 
   /**

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -97,10 +97,10 @@
         <div class="card-body" id="comments-list">
         </div>
         <nav id="comment-nav" hidden>
-          <button class="btn btn-link float-left" type="button" id="prev-comment" onclick="loadComments(this.value)">
+          <button class="btn btn-link float-left" type="button" id="prev-comment" onclick="loadComments(this.value)" hidden>
             <span aria-hidden="true">&larr;</span> Prev
           </button>
-          <button class="btn btn-link float-right" type="button" id="next-comment" onclick="loadComments(this.value)">
+          <button class="btn btn-link float-right" type="button" id="next-comment" onclick="loadComments(this.value)" hidden>
             Next <span aria-hidden="true">&rarr;</span>
           </button>
         </nav>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -96,6 +96,14 @@
         </div>
         <div class="card-body" id="comments-list">
         </div>
+        <nav id="comment-nav" hidden>
+          <button class="btn btn-link float-left" type="button" id="prev-comment" onclick="loadComments(this.value)">
+            <span aria-hidden="true">&larr;</span> Prev
+          </button>
+          <button class="btn btn-link float-right" type="button" id="next-comment" onclick="loadComments(this.value)">
+            Next <span aria-hidden="true">&rarr;</span>
+          </button>
+        </nav>
         <center>
           <div id="comment-no-access-warning" hidden>
             <p class="lead">Permission denied: User does not belong to Google group</p>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -20,6 +20,9 @@ const COMMENT_SECTION_ID        = 'comments-list';
 const COMMENTS_NUMBER_ID        = 'comments-number';
 const COMMENT_TEXT_ID           = 'comment-text';
 const COMMENT_LDAP_ID           = 'ldap';
+const RESPONSE_RESULT_ID        = 'result';
+const RESPONSE_NEXT_CURSOR_ID   = 'next-cursor';
+const RESPONSE_PREV_CURSOR_ID   = 'prev-cursor';
 const COMMENT_SECTION_CHILD_TAG = 'li';
 const AUTH_STATUS_URL           = '/auth-status';
 const LOGIN_URL                 = '/auth-login';
@@ -30,7 +33,9 @@ const HREF_ATTRIBUTE            = 'href';
 const LOGIN_LOGOUT_BUTTON_ID    = 'login-logout-button';
 const LOGIN_MESSAGE             = 'Login';
 const LOGOUT_MESSAGE            = 'Logout';
-const GOOGLER_ELEMENT_IDS       = ['comment-controls'];
+const NEXT_COMMENT_ID           = 'next-comment';
+const PREV_COMMENT_ID           = 'prev-comment';
+const GOOGLER_ELEMENT_IDS       = ['comment-controls', 'comment-nav'];
 const NON_GOOGLER_ELEMENT_IDS   = ['comment-no-access-warning'];
 
 /**
@@ -131,23 +136,36 @@ function clickRandomLink(className) {
   randomLink.click();
 }
 
+function updateCommentNav(prevCursorString, nextCursorString) {
+  const prevButton = document.getElementById(PREV_COMMENT_ID);
+  const nextButton = document.getElementById(NEXT_COMMENT_ID);
+
+  prevButton.value = prevCursorString;
+  nextButton.value = nextCursorString;
+}
+
 /**
- * load comments on homepage.
+ * load comments on homepage and updates the navigation button.
  * The number of comments loaded depends of commentsNumber input. Will always load 5 at minimum.
  * Clears previously loaded comments when called multiple times (done by setting innerHTML = "").
  **/
-async function loadComments() {
+async function loadComments(cursorString) {
   // 'comments-number' magic string is intentionally left as is.
   // This is because constants are taken literally when making objects.
   // Ex: {COMMENTS_NUMBER_ID: commentsNumber} will not become {'comments-number': commentsNumber}
   // even if const COMMENTS_NUMBER_ID = 'comments-number' is declared.
   const commentsNumber  = document.getElementById(COMMENTS_NUMBER_ID).value;
-  const parameters      = {'comments-number': commentsNumber};
+  const parameters      = {'comments-number': commentsNumber, 'cursor': cursorString};
   const fetchUrl        = constructFetchQueryUrl(GET_COMMENT_URL, parameters);
 
-  const commentsJson    = await fetch(fetchUrl);
-  const commentsObject  = await commentsJson.json();
+  const responseJson    = await fetch(fetchUrl);
+  const responseObject  = await responseJson.json();
 
+  const prevCursorString    = responseObject[RESPONSE_PREV_CURSOR_ID];
+  const nextCursorString    = responseObject[RESPONSE_NEXT_CURSOR_ID];
+  updateCommentNav(prevCursorString, nextCursorString);
+
+  const commentsObject      = responseObject[RESPONSE_RESULT_ID];
   const commentSection      = document.getElementById(COMMENT_SECTION_ID);
   commentSection.innerHTML  = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -136,12 +136,16 @@ function clickRandomLink(className) {
   randomLink.click();
 }
 
+/**
+ * Helper function to update the comment navigation buttons
+ * Will hide buttons that are not usable (prev button on first page and next button on last page).
+ **/
 async function updateCommentNav(prevCursorString, nextCursorString, currentResponse) {
   const prevButton = document.getElementById(PREV_COMMENT_ID);
   const nextButton = document.getElementById(NEXT_COMMENT_ID);
 
-  const prevPageResponse = await getComment(prevCursorString);
-  const nextPageResponse = await getComment(nextCursorString);
+  const prevPageResponse = await getCommentResponse(prevCursorString);
+  const nextPageResponse = await getCommentResponse(nextCursorString);
 
   if (JSON.stringify(prevPageResponse) === JSON.stringify(currentResponse)) {
     prevButton.setAttribute(HIDDEN_ATTRIBUTE, true);
@@ -165,13 +169,13 @@ async function updateCommentNav(prevCursorString, nextCursorString, currentRespo
  * Clears previously loaded comments when called multiple times (done by setting innerHTML = "").
  **/
 async function loadComments(cursorString) {
-  const responseObject      = await getComment(cursorString);
+  const responseObject      = await getCommentResponse(cursorString);
 
   const commentsObject      = responseObject[RESPONSE_RESULT_ID];
   const prevCursorString    = responseObject[RESPONSE_PREV_CURSOR_ID];
   const nextCursorString    = responseObject[RESPONSE_NEXT_CURSOR_ID];
 
- await updateCommentNav(prevCursorString, nextCursorString, responseObject);
+  await updateCommentNav(prevCursorString, nextCursorString, responseObject);
 
   const commentSection      = document.getElementById(COMMENT_SECTION_ID);
   commentSection.innerHTML  = "";
@@ -185,11 +189,12 @@ async function loadComments(cursorString) {
   }
 }
 
-async function getComment(cursorString) {
-  // 'comments-number' magic string is intentionally left as is.
-  // This is because constants are taken literally when making objects.
-  // Ex: {COMMENTS_NUMBER_ID: commentsNumber} will not become {'comments-number': commentsNumber}
-  // even if const COMMENTS_NUMBER_ID = 'comments-number' is declared.
+/**
+ * Helper function to get response from GET_COMMENT_URL.
+ * 'comments-number' magic string is intentionally left as is.
+ * This is because constants are taken literally when making objects.
+ **/
+async function getCommentResponse(cursorString) {
   const commentsNumber  = document.getElementById(COMMENTS_NUMBER_ID).value;
   const parameters      = {'comments-number': commentsNumber, 'cursor': cursorString};
   const fetchUrl        = constructFetchQueryUrl(GET_COMMENT_URL, parameters);
@@ -200,6 +205,12 @@ async function getComment(cursorString) {
   return responseObject;
 }
 
+/**
+ * Function used to post a new comment typed in COMMENT_TEXT_ID element.
+ * Clears out the typed comment and reloads the comments section.
+ * 'comments-number' magic string is intentionally left as is.
+ * This is because constants are taken literally when making objects.
+ **/
 async function postComment() {
   const commentText = document.getElementById(COMMENT_TEXT_ID).value;
   const parameters  = {'comment-text': commentText};


### PR DESCRIPTION
- Add pagination support to DataServlet class
- Add server side cursor caching to keep track of cursor to previous pages
- Add pagination feature and UI to comments section
- Move datastore initialization to costructor to make datastore usage more efficient

Screenshots:
- https://screenshot.googleplex.com/V9ZQCXoYZrE.png (when there's only next comments)
- https://screenshot.googleplex.com/TB0BrsmCSBp.png (when there's only prev comments)
- https://screenshot.googleplex.com/86ydpj8m2bp.png (when there's both prev and next comments)
- https://screenshot.googleplex.com/2W7iG5ROuoc.png (when there's no prev or next comments)